### PR TITLE
Restart named instances of SQL server as well as the default

### DIFF
--- a/Installation/ImportSQL.ps1
+++ b/Installation/ImportSQL.ps1
@@ -42,7 +42,7 @@ if($CertInStore){
         }
         # The thumbprint must be in all lowercase, otherwise SQL server doesn't seem to accept it?!
         Set-ItemProperty $regKey.PSPath -Name "Certificate" -Value $NewCertThumbprint.ToLowerInvariant()
-        Restart-Service MSSQLSERVER -Force -ErrorAction Stop
+        Restart-Service 'MSSQL*' -Force -ErrorAction Stop
         "Cert thumbprint set to SQL and service restarted"
     }catch{
         "Cert thumbprint was not set successfully"


### PR DESCRIPTION
The existing script successfully sets the thumbprint in the registry for named instances of SQL Server, but only tries to restart the default instance. This commit matches both the default service name "MSSQLSERVER" and named ones "MSSQL$EXAMPLENAME", as documented [on Microsoft Learn](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/manage-the-database-engine-services?view=sql-server-ver17#use-the-sql-server-service).